### PR TITLE
Consolidate duplicate env-var parsing in config.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,11 +542,12 @@ The project has evolved from permanent deletion to a comprehensive archive syste
 
 #### Configuration System
 
-**Environment Variables**:
+**Environment Variables** (all use `HYPR_` prefix, configured via `from_env()`):
 ```bash
-export ARCHIVE_ENABLED=true              # Enable/disable archive system
-export ARCHIVE_MAX_SESSIONS=20           # Maximum archived sessions to keep
-export ARCHIVE_AUTO_CLEANUP=true         # Automatic cleanup when limit exceeded
+export HYPR_ARCHIVE_ENABLED=true              # Enable/disable archive system
+export HYPR_ARCHIVE_MAX=20                    # Maximum archived sessions to keep
+export HYPR_ARCHIVE_AUTO_CLEANUP=true         # Automatic cleanup when limit exceeded
+export HYPR_ARCHIVE_CLEANUP_STRATEGY=oldest_first  # or largest_first
 ```
 
 **Runtime Configuration** (`commands/shared/config.py`):

--- a/commands/shared/config.py
+++ b/commands/shared/config.py
@@ -47,32 +47,8 @@ class SessionConfig:
     # Debug Configuration
     debug_enabled: bool = False
 
-    def _validate_env_numeric(self, env_var: str, current_value, min_val, max_val, value_type=int):
-        """Validate and set numeric environment variable with bounds checking"""
-        if env_var in os.environ:
-            try:
-                new_value = value_type(os.environ[env_var])
-                if min_val <= new_value <= max_val:
-                    return new_value
-                else:
-                    print(f"Warning: {env_var} value {new_value} out of range ({min_val}-{max_val}), using default {current_value}")
-                    return current_value
-            except ValueError:
-                print(f"Warning: Invalid {env_var} value '{os.environ[env_var]}', using default {current_value}")
-        return current_value
-
     def __post_init__(self) -> None:
-        """Initialize default values and apply environment variable overrides"""
-        # Apply environment variable overrides for archive settings with bounds validation
-        self.archive_max_sessions = self._validate_env_numeric(
-            "ARCHIVE_MAX_SESSIONS", self.archive_max_sessions, 1, 1000
-        )
-        
-        if "ARCHIVE_AUTO_CLEANUP" in os.environ:
-            self.archive_auto_cleanup = os.environ["ARCHIVE_AUTO_CLEANUP"].lower() in ("true", "1", "yes")
-        
-        if "ARCHIVE_ENABLED" in os.environ:
-            self.archive_enabled = os.environ["ARCHIVE_ENABLED"].lower() in ("true", "1", "yes")
+        """Initialize default values for mutable fields and ensure directory structure"""
         if self.supported_browsers is None:
             self.supported_browsers = {
                 "zen-alpha",  # Zen Browser (alpha)


### PR DESCRIPTION
## Summary

- Removed `_validate_env_numeric()` instance method that used raw `print()` for warnings
- Removed direct `os.environ` reads from `__post_init__` for non-prefixed env vars (`ARCHIVE_MAX_SESSIONS`, `ARCHIVE_AUTO_CLEANUP`, `ARCHIVE_ENABLED`)
- `from_env()` is now the single env-var parsing path using consistent `HYPR_` prefixed variables
- Updated CLAUDE.md documentation to reflect the correct `HYPR_`-prefixed env var names

This eliminates three overlapping env-var parsing systems (instance method, static methods, direct reads) and two conflicting namespaces (unprefixed vs `HYPR_` prefix) that could silently overwrite each other.

## What was NOT changed (out of scope)

- `_safe_int_from_env()` / `_safe_float_from_env()` static methods (kept as the canonical parsers)
- Path getter methods and `__post_init__` mkdir/migration logic (handled by #3)

## Test plan

- [x] `python -m py_compile commands/shared/config.py` passes
- [ ] Verify `SessionConfig()` (no env vars) uses dataclass defaults
- [ ] Verify `SessionConfig.from_env()` reads `HYPR_`-prefixed env vars correctly
- [ ] Verify no code reads the old unprefixed env vars

Closes #4