### PR TITLE
Remove mkdir side-effects from SessionConfig path methods

### DIFF
--- a/commands/delete.py
+++ b/commands/delete.py
@@ -39,12 +39,10 @@ class SessionArchive(Utils):
             SessionValidator.validate_session_exists(session_dir, session_name)
             result.add_success("Session exists and is accessible")
             
-            # Now get the session directory (it won't create since it exists)
-            session_dir = self.config.get_active_session_directory(session_name)
             self.debugger.debug(f"Session directory path: {session_dir}")
             
-            # Validate archived sessions directory is accessible
-            SessionValidator.validate_archived_sessions_dir(self.config.get_archived_sessions_dir())
+            # Validate archived sessions directory is accessible (ensure it exists for writing)
+            SessionValidator.validate_archived_sessions_dir(self.config.ensure_archived_sessions_dir())
             result.add_success("Archived sessions directory accessible")
             
         except (SessionValidationError, SessionNotFoundError) as e:
@@ -67,7 +65,7 @@ class SessionArchive(Utils):
             archived_dir = self.config.get_archived_session_directory(archived_name)
             
             # METADATA-FIRST PATTERN: Create metadata in temporary location first
-            archived_sessions_dir = self.config.get_archived_sessions_dir()
+            archived_sessions_dir = self.config.ensure_archived_sessions_dir()
             temp_metadata_file = archived_sessions_dir / f".archive-metadata-{archived_name}.tmp"
             metadata = self._create_archive_metadata(session_name, archived_name, file_count)
             

--- a/commands/recover.py
+++ b/commands/recover.py
@@ -212,9 +212,8 @@ class SessionRecovery(Utils):
             
             result.add_success("Target session name is available")
             
-            # Ensure active sessions directory exists
-            active_sessions_dir: Path = self.config.get_active_sessions_dir()
-            active_sessions_dir.mkdir(parents=True, exist_ok=True)
+            # Ensure active sessions directory exists for the recovery write
+            self.config.ensure_active_sessions_dir()
             
         except (SessionValidationError, SessionNotFoundError, SessionAlreadyExistsError) as e:
             self.debugger.debug(f"Validation error: {e}")

--- a/commands/save/session_saver.py
+++ b/commands/save/session_saver.py
@@ -195,7 +195,7 @@ class SessionSaver(Utils):
                         if neovide_session_info:
                             window_data["neovide_session"] = neovide_session_info
                             # Try to create/capture session file in session directory
-                            session_dir = str(self.config.get_active_session_directory(self.current_session_name))
+                            session_dir = str(self.config.ensure_active_session_directory(self.current_session_name))
                             session_file = self.neovide_handler.create_session_file(pid, session_dir)
                             self.debugger.debug(f"Created session file: {session_file}")
                             if session_file:
@@ -276,7 +276,8 @@ class SessionSaver(Utils):
                 self.debugger.debug(f"  Group {group_id[:8]}... has {len(addresses)} windows")
             result.add_success(f"Detected {len(groups)} window groups")
 
-        # Save session to file in new folder structure
+        # Save session to file in new folder structure (ensure directory exists)
+        self.config.ensure_active_session_directory(session_name)
         session_file = self.config.get_active_session_file_path(session_name)
         try:
             with open(session_file, "w") as f:

--- a/commands/shared/config.py
+++ b/commands/shared/config.py
@@ -95,11 +95,9 @@ class SessionConfig:
                 "neovide": "neovide",
             }
 
-        # Ensure sessions directory exists
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
-        
-        # Perform automatic migration if needed
-        self._ensure_folder_structure()
+        # Note: Directory creation and migration are deferred to initialize_storage()
+        # to avoid side-effects during construction. The CLI entry point calls
+        # initialize_storage() explicitly before any operations.
 
     @staticmethod
     def _safe_int_from_env(env_var: str, default_value: int, min_val: int, max_val: int) -> int:
@@ -178,15 +176,11 @@ class SessionConfig:
 
     def get_session_file_path(self, session_name: str) -> Path:
         """Get the full path for a session file in the new folder structure"""
-        session_dir = self.sessions_dir / session_name
-        session_dir.mkdir(parents=True, exist_ok=True)
-        return session_dir / "session.json"
+        return (self.sessions_dir / session_name) / "session.json"
 
     def get_session_directory(self, session_name: str) -> Path:
         """Get the session directory path"""
-        session_dir = self.sessions_dir / session_name
-        session_dir.mkdir(parents=True, exist_ok=True)
-        return session_dir
+        return self.sessions_dir / session_name
 
     def get_neovide_session_file_path(self, session_name: str, pid: int) -> Path:
         """Get the path for a Neovide session file within a session directory"""
@@ -204,22 +198,28 @@ class SessionConfig:
     # Archive System Methods
     
     def get_active_sessions_dir(self) -> Path:
-        """Get the active sessions directory path (new folder structure)"""
-        active_dir = self.sessions_dir / "sessions"
-        active_dir.mkdir(parents=True, exist_ok=True)
-        return active_dir
+        """Get the active sessions directory path (new folder structure).
+
+        Returns the path without creating the directory. Use ensure_active_sessions_dir()
+        when the directory must exist for write operations.
+        """
+        return self.sessions_dir / "sessions"
     
     def get_archived_sessions_dir(self) -> Path:
-        """Get the archived sessions directory path"""
-        archived_dir = self.sessions_dir / "archived"
-        archived_dir.mkdir(parents=True, exist_ok=True)
-        return archived_dir
+        """Get the archived sessions directory path.
+
+        Returns the path without creating the directory. Use ensure_archived_sessions_dir()
+        when the directory must exist for write operations.
+        """
+        return self.sessions_dir / "archived"
     
     def get_active_session_directory(self, session_name: str) -> Path:
-        """Get an active session directory path (new structure)"""
-        session_dir = self.get_active_sessions_dir() / session_name
-        session_dir.mkdir(parents=True, exist_ok=True)
-        return session_dir
+        """Get an active session directory path (new structure).
+
+        Returns the path without creating the directory. Use ensure_active_session_directory()
+        when the directory must exist for write operations.
+        """
+        return self.get_active_sessions_dir() / session_name
     
     def get_active_session_file_path(self, session_name: str) -> Path:
         """Get the active session file path (new structure)"""
@@ -237,6 +237,37 @@ class SessionConfig:
         """Get the archive metadata file path"""
         return self.get_archived_session_directory(archived_session_name) / ".archive-metadata.json"
     
+    # --- Directory creation methods (ensure_*) ---
+    # Use these when the directory MUST exist for write operations.
+
+    def ensure_active_sessions_dir(self) -> Path:
+        """Return the active sessions directory, creating it if necessary."""
+        active_dir = self.get_active_sessions_dir()
+        active_dir.mkdir(parents=True, exist_ok=True)
+        return active_dir
+
+    def ensure_archived_sessions_dir(self) -> Path:
+        """Return the archived sessions directory, creating it if necessary."""
+        archived_dir = self.get_archived_sessions_dir()
+        archived_dir.mkdir(parents=True, exist_ok=True)
+        return archived_dir
+
+    def ensure_active_session_directory(self, session_name: str) -> Path:
+        """Return an active session directory, creating it if necessary."""
+        session_dir = self.get_active_session_directory(session_name)
+        session_dir.mkdir(parents=True, exist_ok=True)
+        return session_dir
+
+    def initialize_storage(self) -> None:
+        """Create base directories and run any pending migrations.
+
+        Call this once from the CLI entry point before performing operations.
+        Separated from __post_init__ so that constructing a SessionConfig for
+        path queries alone does not trigger filesystem side-effects.
+        """
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self._ensure_folder_structure()
+
     def _ensure_folder_structure(self) -> None:
         """Ensure proper folder structure and migrate if needed"""
         # Check if we need to migrate from old flat structure to new nested structure
@@ -271,8 +302,8 @@ class SessionConfig:
         print("🔄 Migrating session storage to new archive-enabled structure...")
         
         # Create the new directories
-        active_dir = self.get_active_sessions_dir()
-        archived_dir = self.get_archived_sessions_dir()
+        active_dir = self.ensure_active_sessions_dir()
+        archived_dir = self.ensure_archived_sessions_dir()
         
         # Find all session directories in root
         session_dirs = [d for d in self.sessions_dir.iterdir() 

--- a/hypr-sessions.py
+++ b/hypr-sessions.py
@@ -435,6 +435,10 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    # Ensure storage directories exist and migrations are applied before any operation.
+    config = get_config()
+    config.initialize_storage()
+
     manager = HyprlandSessionManager(debug=args.debug, json_output=args.json)
 
     if args.action == "save":


### PR DESCRIPTION
## Summary

- Path getter methods on `SessionConfig` now return pure paths without creating directories as a side-effect
- Added `ensure_*` counterparts (`ensure_active_sessions_dir`, `ensure_archived_sessions_dir`, `ensure_active_session_directory`) for callers that need the directory to exist before writing
- Moved directory creation and migration logic from `__post_init__` into `initialize_storage()`, called once from the CLI entry point in `main()`
- Updated all write-path callers (`session_saver.py`, `delete.py`, `recover.py`) to use `ensure_*` methods; read-only callers (`list.py`, `restore.py`, `health_check`) remain unchanged

Fixes #3

## Test plan

- [ ] Run `python -m py_compile` on all modified files (verified passing)
- [ ] Run `./hypr-sessions.py list` to confirm read-only path works without side-effects
- [ ] Run `./hypr-sessions.py save test-session` to confirm directory creation on write
- [ ] Run `./hypr-sessions.py delete test-session` to confirm archive directory creation
- [ ] Run `./hypr-sessions.py health` to confirm health check does not create dirs